### PR TITLE
Win-Win im Häuserkauf verhindern

### DIFF
--- a/Altis_Life.Altis/core/housing/fn_buyHouse.sqf
+++ b/Altis_Life.Altis/core/housing/fn_buyHouse.sqf
@@ -1,7 +1,7 @@
 #include <macro.h>
 /*
 	Author: Bryan "Tonic" Boardwine
-	
+
 	Description:
 	Buys the house?
 */
@@ -40,6 +40,13 @@ if(D41_atmGeld < (_houseCfg select 0)) exitWith {hint format [localize "STR_Hous
 
 if(_action) then {
 	if(D41_atmGeld < (_houseCfg select 0)) exitWith {hint format [localize "STR_House_NotEnough"]};
+
+	// We want to remove the money before adding the house
+	D41_atmGeld = D41_atmGeld - (_houseCfg select 0);
+	[1] SOCK_fnc_updatePartial;
+	// Optional: Wait a short moment to prevent Alt+F4 before the updatePartial was completed
+	// sleep 0.5;
+
 	[[_uid,_house],"TON_fnc_addHouse",false,false] call life_fnc_MP;
 	_house setVariable["house_owner",[_uid,profileName],true];
 	_house setVariable["house_soldCheck",false,true];
@@ -47,7 +54,6 @@ if(_action) then {
 	_house setVariable["house_owned",true,true];
 	_house setVariable["containers",[],true];
 	_house setVariable["uid",round(random 99999),true];
-	D41_atmGeld = D41_atmGeld - (_houseCfg select 0);
 	life_vehicles pushBack _house;
 	life_houses pushBack [str(getPosATL _house),[]];
 	_marker = createMarkerLocal [format["house_%1",(_house getVariable "uid")],getPosATL _house];

--- a/Altis_Life.Bornholm/core/housing/fn_buyHouse.sqf
+++ b/Altis_Life.Bornholm/core/housing/fn_buyHouse.sqf
@@ -1,7 +1,7 @@
 #include <macro.h>
 /*
 	Author: Bryan "Tonic" Boardwine
-	
+
 	Description:
 	Buys the house?
 */
@@ -40,6 +40,13 @@ if(D41_atmGeld < (_houseCfg select 0)) exitWith {hint format [localize "STR_Hous
 
 if(_action) then {
 	if(D41_atmGeld < (_houseCfg select 0)) exitWith {hint format [localize "STR_House_NotEnough"]};
+
+	// We want to remove the money before adding the house
+	D41_atmGeld = D41_atmGeld - (_houseCfg select 0);
+	[1] SOCK_fnc_updatePartial;
+	// Optional: Wait a short moment to prevent Alt+F4 before the updatePartial was completed
+	// sleep 0.5;
+	
 	[[_uid,_house],"TON_fnc_addHouse",false,false] call life_fnc_MP;
 	_house setVariable["house_owner",[_uid,profileName],true];
 	_house setVariable["house_soldCheck",false,true];
@@ -47,7 +54,6 @@ if(_action) then {
 	_house setVariable["house_owned",true,true];
 	_house setVariable["containers",[],true];
 	_house setVariable["uid",round(random 99999),true];
-	D41_atmGeld = D41_atmGeld - (_houseCfg select 0);
 	life_vehicles pushBack _house;
 	life_houses pushBack [str(getPosATL _house),[]];
 	_marker = createMarkerLocal [format["house_%1",(_house getVariable "uid")],getPosATL _house];


### PR DESCRIPTION
Möglichen Exploit beim Häuserkauf verhindern (Haus Kaufen und direkt danach Alt+F4 drücken -> Geld behalten und ein neues Haus besitzen, dann das Haus verkaufen -> $$$).